### PR TITLE
Refactor: AdminController and AdminService 리펙토링

### DIFF
--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -52,7 +52,7 @@ public class AdminController {
         @PathVariable("id") Long id
     ) {
         adminService.deleteUserById(id);
-        return ApiResponse.success(AdminSuccessMessage.USER_DELETED.getMessage());
+        return ApiResponse.noContent();
     }
 
     @PatchMapping("/user-info/{id}/lock")

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminController.java
@@ -28,29 +28,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {
-    // TODO 해당 url들이 restful인지 확인하기
-    // 해당 반환값들이 정말 필요한지 확인해보기
+
     private final AdminService adminService;
 
-    @GetMapping("/dashboard")
-    public String dashboard() {
-        return "admin/dashboard";
-    }
-
     @GetMapping("/user-info")
-    public ApiResponse<Page<UserInfoResponse>> userInfos(
+    public ApiResponse<Page<UserInfoResponse>> getUserInfos(
         @ModelAttribute UserSearchRequest request
     ) {
         return ApiResponse.success(adminService.findUsersPage(request));
     }
 
-    @PatchMapping("/user-info/{id}/edit")
-    public ApiResponse<String> editUserInfo(
+    @PatchMapping("/user-info/{id}")
+    public ApiResponse<String> updateUserInfo(
         @PathVariable("id") Long id,
         @RequestBody UserInfoUpdateRequest request
     ) {
         adminService.updateUserInfo(id, request);
         return ApiResponse.success(AdminSuccessMessage.USER_INFO_UPDATED.getMessage());
+    }
+
+    @DeleteMapping("/user-info/{id}")
+    public ApiResponse<String> deleteUserInfo(
+        @PathVariable("id") Long id
+    ) {
+        adminService.deleteUserById(id);
+        return ApiResponse.success(AdminSuccessMessage.USER_DELETED.getMessage());
     }
 
     @PatchMapping("/user-info/{id}/lock")
@@ -69,16 +71,8 @@ public class AdminController {
         return ApiResponse.success(AdminSuccessMessage.USER_UNLOCKED.getMessage());
     }
 
-    @DeleteMapping("/user-info/{id}/delete")
-    public ApiResponse<String> deleteUserInfo(
-        @PathVariable("id") Long id
-    ) {
-        adminService.deleteById(id);
-        return ApiResponse.success(AdminSuccessMessage.USER_DELETED.getMessage());
-    }
-
     @GetMapping("/statistic")
-    public ApiResponse<StatisticResponse> statistic() {
+    public ApiResponse<StatisticResponse> getStatistics() {
         StatisticResponse statisticResponse = StatisticResponse
             .builder()
             .countries(adminService.getCountriesStatistics())

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchRequest.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchRequest.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 @Builder
 @AllArgsConstructor
 public class UserSearchRequest {
-    private Boolean locked;
+    private Boolean isLocked;
     private int page;
     private int size;
 

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchRequest.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/admin/dto/user/UserSearchRequest.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 @Builder
 @AllArgsConstructor
 public class UserSearchRequest {
-    private boolean locked;
+    private Boolean locked;
     private int page;
     private int size;
 

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
@@ -31,7 +31,7 @@ public class AdminService {
     private final TravelPlanQueryRepository travelPlanQueryRepository;
 
     public Page<UserInfoResponse> findUsersPage(UserSearchRequest userSearchRequest) {
-        Boolean isLocked = userSearchRequest.getLocked();
+        Boolean isLocked = userSearchRequest.getIsLocked();
         Pageable pageable = userSearchRequest.getPageable();
         Page<User> lockedUserInfos = userQueryRepository.findUsersPage(isLocked, pageable);
         return lockedUserInfos.map(UserInfoResponse::of);

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
@@ -33,7 +33,7 @@ public class AdminService {
     public Page<UserInfoResponse> findUsersPage(UserSearchRequest userSearchRequest) {
         boolean isLocked = userSearchRequest.isLocked();
         Pageable pageable = userSearchRequest.getPageable();
-        Page<User> lockedUserInfos = userQueryRepository.findUsersByLockStatus(isLocked, pageable);
+        Page<User> lockedUserInfos = userQueryRepository.findUsersPage(isLocked, pageable);
         return lockedUserInfos.map(UserInfoResponse::of);
     }
 
@@ -49,14 +49,6 @@ public class AdminService {
             request.getPhoneNumber(),
             null
         );
-    }
-
-    public boolean isDuplicatedEmail(String email) {
-        return userRepository.findByEmail(email).isPresent();
-    }
-
-    public boolean isDuplicatedUsername(String username) {
-        return userRepository.findByName(username).isPresent();
     }
 
     @Transactional
@@ -96,6 +88,14 @@ public class AdminService {
 
     public List<CountriesStatisticResponse> getCountriesStatistics() {
         return travelPlanQueryRepository.getCountriesStatistics();
+    }
+
+    public boolean isDuplicatedEmail(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
+
+    public boolean isDuplicatedUsername(String username) {
+        return userRepository.findByName(username).isPresent();
     }
 
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminService {
-    // TODO 메서드 명 고치기
     private final UserRepository userRepository;
     private final UserQueryRepository userQueryRepository;
     private final TravelPlanRepository travelPlanRepository;
@@ -62,24 +61,24 @@ public class AdminService {
 
     @Transactional
     public void lockUser(Long userId) {
-        User user = findUserAndCheckAdminRole(userId);
+        User user = getModifiableUser(userId);
         user.lock();
     }
 
     @Transactional
     public void unlockUser(Long userId) {
-        User user = findUserAndCheckAdminRole(userId);
+        User user = getModifiableUser(userId);
         user.unlock();
     }
 
     @Transactional
-    public void deleteById(Long userId) {
-        User user = findUserAndCheckAdminRole(userId);
+    public void deleteUserById(Long userId) {
+        User user = getModifiableUser(userId);
         travelPlanRepository.deleteByUserId(userId);
         userRepository.delete(user);
     }
 
-    private User findUserAndCheckAdminRole(Long userId) {
+    private User getModifiableUser(Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new NotFoundException(ExceptionMessage.USER_NOT_FOUND));
         if(user.isAdmin()) {

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/admin/AdminService.java
@@ -31,7 +31,7 @@ public class AdminService {
     private final TravelPlanQueryRepository travelPlanQueryRepository;
 
     public Page<UserInfoResponse> findUsersPage(UserSearchRequest userSearchRequest) {
-        boolean isLocked = userSearchRequest.isLocked();
+        Boolean isLocked = userSearchRequest.getLocked();
         Pageable pageable = userSearchRequest.getPageable();
         Page<User> lockedUserInfos = userQueryRepository.findUsersPage(isLocked, pageable);
         return lockedUserInfos.map(UserInfoResponse::of);

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserQueryRepository.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserQueryRepository.java
@@ -36,9 +36,7 @@ public class UserQueryRepository {
 
     public Page<User> findUsersPage(Boolean isLocked, Pageable pageable) {
 
-        BooleanExpression lockStatus = Optional.ofNullable(isLocked)
-            .map(user.isLocked::eq)
-            .orElse(null);
+        BooleanExpression lockStatus = (isLocked != null) ? user.isLocked.eq(isLocked) : null;
 
         List<User> users = queryFactory
             .selectFrom(user)

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserQueryRepository.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserQueryRepository.java
@@ -36,7 +36,9 @@ public class UserQueryRepository {
 
     public Page<User> findUsersPage(Boolean isLocked, Pageable pageable) {
 
-        BooleanExpression lockStatus = createLockStatusCondition(isLocked);
+        BooleanExpression lockStatus = Optional.ofNullable(isLocked)
+            .map(user.isLocked::eq)
+            .orElse(null);
 
         List<User> users = queryFactory
             .selectFrom(user)
@@ -53,10 +55,4 @@ public class UserQueryRepository {
         return new PageImpl<>(users, pageable, total);
     }
 
-    private BooleanExpression createLockStatusCondition(Boolean isLocked) {
-        return Optional.ofNullable(isLocked)
-            .map(user.isLocked::eq)
-            .orElse(null);
-
-    }
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserQueryRepository.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/user/repository/UserQueryRepository.java
@@ -34,13 +34,13 @@ public class UserQueryRepository {
                 .fetchOne();
     }
 
-    public Page<User> findUsersByLockStatus(Boolean isLocked, Pageable pageable) {
+    public Page<User> findUsersPage(Boolean isLocked, Pageable pageable) {
 
         BooleanExpression lockStatus = createLockStatusCondition(isLocked);
 
         List<User> users = queryFactory
             .selectFrom(user)
-            .where(lockStatus) // 동적 조건 적용
+            .where(lockStatus)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/global/message/AdminSuccessMessage.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/global/message/AdminSuccessMessage.java
@@ -6,13 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AdminSuccessMessage {
-    USER_INFO_UPDATED("유저 정보가 성공적으로 수정되었습니다."),
+    USER_INFO_UPDATED("유저 정보가 수정되었습니다."),
     USER_LOCKED("유저를 잠금처리하였습니다."),
     USER_UNLOCKED("유저를 잠금해제하였습니다."),
     USER_DELETED("유저를 탈퇴처리하였습니다."),
-    PLACE_UPDATED("여행지 정보가 변경되었습니다."),
-    PLACE_DELETED("여행지 정보가 삭제되었습니다.")
-    ;
+    PLACE_UPDATED("여행지 정보가 수정되었습니다.");
 
     private final String message;
 }

--- a/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerTest.java
+++ b/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerTest.java
@@ -40,7 +40,7 @@ class AdminControllerTest {
             .build();
 
         // when
-        ApiResponse<Page<UserInfoResponse>> result = adminController.userInfos(request);
+        ApiResponse<Page<UserInfoResponse>> result = adminController.getUserInfos(request);
 
         // then
         List<UserInfoResponse> content = result.data().getContent();
@@ -67,7 +67,7 @@ class AdminControllerTest {
             .build();
 
         // when
-        ApiResponse<Page<UserInfoResponse>> result = adminController.userInfos(request);
+        ApiResponse<Page<UserInfoResponse>> result = adminController.getUserInfos(request);
 
         // then
         List<UserInfoResponse> content = result.data().getContent();

--- a/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerTest.java
+++ b/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/api/controller/admin/AdminControllerTest.java
@@ -34,7 +34,7 @@ class AdminControllerTest {
         // given
         UserSearchRequest request = UserSearchRequest
             .builder()
-            .locked(true)
+            .isLocked(true)
             .page(0)
             .size(10)
             .build();
@@ -61,7 +61,7 @@ class AdminControllerTest {
         // given
         UserSearchRequest request = UserSearchRequest
             .builder()
-            .locked(false)
+            .isLocked(false)
             .page(0)
             .size(5)
             .build();


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- AdminController에서 url 변경과 메서드명을 변경
- AdminService에서 메서드명을 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
#### AdminController
- editUserInfo -> updateUserInfo로 변경했습니다.
- UserInfo에 대한 Patch 요청에 대한 url에서 edit이라는 엔드포인트를 제거했습니다(해당 id의 유저에 대한 Patch 요청이기때문에 url상으로 다른건 restful 원칙에 맞지 않다고 생각했습니다.)
- UserInfo에 대한 Delete 요청에 대한 url에서 delete라는 엔드포인트를 제거했습니다(해당 id의 유저에 대한Delete 요청이기때문에 url상으로 다른건 restful 원칙에 맞지 않다고 생각했습니다.)
- unlockUser와 lockUser에 대한 요청을 분리했습니다. 또한, 해당 요청을 구분하기 위해 엔드포인트에 lock과 unlock을 추가했습니다.
---
#### AdminService
- findUserAndCheckAdminRole 메서드를 getModifiableUser로 변경하였습니다 (그냥 findUser로 해둘까 했지만 존재하지 않는 유저와 변경이 불가능한 관리자를 걸러내고 변경이 가능한 유저를 가져오는 것이니 해당 메서드명이 적절하지 않을까 생각했습니다.)
- UserQueryRepository의 findUserByLockStatus를 findUsersPage로 변경하였습니다.(필터링이 담겨있다는 것 표현하면 좋겠다고 생각했는데 그냥 findUsersPage로 해두는게 좋지않을까 생각하기도 했고 다른 좋은 이름이 생각나지 않았습니다.)
---
#### AdminSuccessMessage
Patch나 Delete 요청에 대한 성공응답으로 각 요청에 맞는 성공메시지를 보내도록 하였습니다.
이건 그냥 요청에 대한 성공여부에 true를 Collections.singletonMap("duplicated", true) 이런식으로 담아 보낼까 했는데 이러면 프론트단에서 해당 요청에 대한 성공메시지를 true일때 표시하도록 해야하는데 이걸 희제님이 일일이 하시는건 시간 낭비일 것같다고 생각해 성공메시지를 담아서 보내면 이것만 띄우면 되니까 크게 생각하지 않아도 되어 편하지 않을까 하는 생각에 성공메시지를 담아 보내도록 해두었습니다.
-  아무래도 Delete는 RestFul 원칙지켜서 noContent로 보내는 게 맞을 것같아 noContent로 변경하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- unlockUser와 lockUser에 대한 요청을 분리했습니다
-> 이 부분은 그냥 updateUserLock으로 하고 현재 isLock의 상태를 not해서 업데이트 시키는 로직으로 바꿀까 생각했는데 어떤게 좋을지 잘 몰라 일단 분리시킨 채로 두었습니다.
- 메서드명은 GPT랑 Gemini 굴려가면서 최대한 읽기 편할 것같도록 고쳤습니다.
