### PR TITLE
Feat: AI 예상 이동 시간을 TravelSchedule에 함께 저장하도록 추가

### DIFF
--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/travelSchedule/TravelScheduleController.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/travelSchedule/TravelScheduleController.java
@@ -12,10 +12,17 @@ import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.service.TravelScheduleService;
 import grepp.NBE5_6_2_Team03.global.response.ApiResponse;
 import grepp.NBE5_6_2_Team03.global.response.ResponseCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/travel-plans/{travelPlanId}/schedule")
 @RequiredArgsConstructor
@@ -26,23 +33,27 @@ public class TravelScheduleController {
     private final TravelTimeAiService travelTimeAiService;
 
     @GetMapping("/group")
-    public ApiResponse<GroupedTravelSchedulesResponse> findSchedulesGroupByDate(@PathVariable("travelPlanId") Long travelPlanId) {
-        GroupedTravelSchedulesResponse response = travelScheduleService.getGroupedSchedules(travelPlanId);
+    public ApiResponse<GroupedTravelSchedulesResponse> findSchedulesGroupByDate(
+        @PathVariable("travelPlanId") Long travelPlanId) {
+        GroupedTravelSchedulesResponse response = travelScheduleService.getGroupedSchedules(
+            travelPlanId);
         return ApiResponse.success(response);
     }
 
     @GetMapping("/{travelScheduleId}")
-    public ApiResponse<TravelScheduleResponse> findSchedule(@PathVariable("travelPlanId") Long travelPlanId,
-                                                            @PathVariable("travelScheduleId") Long travelScheduleId) {
+    public ApiResponse<TravelScheduleResponse> findSchedule(
+        @PathVariable("travelPlanId") Long travelPlanId,
+        @PathVariable("travelScheduleId") Long travelScheduleId) {
         TravelSchedule schedule = travelScheduleService.findById(travelScheduleId);
         return ApiResponse.success(TravelScheduleResponse.fromEntity(schedule));
     }
 
     @PostMapping("/new")
     public ApiResponse<Object> createSchedule(@PathVariable("travelPlanId") Long travelPlanId,
-                                              @RequestBody TravelScheduleRequest request) {
+        @RequestBody TravelScheduleRequest request) {
         try {
-            TravelSchedule travelSchedule =  travelScheduleService.createSchedule(travelPlanId, request);
+            TravelSchedule travelSchedule = travelScheduleService.createSchedule(travelPlanId,
+                request);
             return ApiResponse.success(TravelScheduleResponse.fromEntity(travelSchedule));
         } catch (IllegalArgumentException e) {
             return ApiResponse.error(ResponseCode.BAD_REQUEST, Map.of("error", e.getMessage()));
@@ -51,10 +62,11 @@ public class TravelScheduleController {
 
     @PutMapping("/{travelScheduleId}")
     public ApiResponse<Object> editSchedule(@PathVariable("travelPlanId") Long travelPlanId,
-                                            @PathVariable("travelScheduleId") Long travelScheduleId,
-                                            @RequestBody TravelScheduleEditRequest request) {
+        @PathVariable("travelScheduleId") Long travelScheduleId,
+        @RequestBody TravelScheduleEditRequest request) {
         try {
-            TravelSchedule travelSchedule =  travelScheduleService.editSchedule(travelScheduleId, request);
+            TravelSchedule travelSchedule = travelScheduleService.editSchedule(travelScheduleId,
+                request);
             return ApiResponse.success(TravelScheduleEditResponse.fromEntity(travelSchedule));
         } catch (IllegalArgumentException e) {
             return ApiResponse.error(ResponseCode.BAD_REQUEST, Map.of("error", e.getMessage()));
@@ -63,16 +75,18 @@ public class TravelScheduleController {
 
     @DeleteMapping("/{travelScheduleId}")
     public ApiResponse<Void> deleteSchedule(@PathVariable("travelPlanId") Long travelPlanId,
-                               @PathVariable("travelScheduleId") Long travelScheduleId) {
+        @PathVariable("travelScheduleId") Long travelScheduleId) {
         travelScheduleService.deleteSchedule(travelScheduleId);
         return ApiResponse.noContent();
     }
 
     @PatchMapping("/{travelScheduleId}/status")
-    public ApiResponse<TravelScheduleStatusResponse> editScheduleStatus(@PathVariable("travelPlanId") Long travelPlanId,
-                                                                        @PathVariable("travelScheduleId") Long travelScheduleId,
-                                                                        @RequestBody TravelScheduleStatusRequest request) {
-        TravelSchedule travelSchedule = travelScheduleService.editScheduleStatus(travelScheduleId, request);
+    public ApiResponse<TravelScheduleStatusResponse> editScheduleStatus(
+        @PathVariable("travelPlanId") Long travelPlanId,
+        @PathVariable("travelScheduleId") Long travelScheduleId,
+        @RequestBody TravelScheduleStatusRequest request) {
+        TravelSchedule travelSchedule = travelScheduleService.editScheduleStatus(travelScheduleId,
+            request);
         return ApiResponse.success(TravelScheduleStatusResponse.fromEntity(travelSchedule));
     }
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/travelSchedule/dto/request/TravelScheduleRequest.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/travelSchedule/dto/request/TravelScheduleRequest.java
@@ -3,17 +3,19 @@ package grepp.NBE5_6_2_Team03.api.controller.schedule.travelSchedule.dto.request
 import grepp.NBE5_6_2_Team03.api.controller.schedule.traveltimeai.dto.TravelTimeRequest;
 import grepp.NBE5_6_2_Team03.api.controller.schedule.traveltimeai.dto.TravelTimeResponse;
 import grepp.NBE5_6_2_Team03.domain.schedule.treveltimeai.service.TravelTimeAiService;
+import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
+import grepp.NBE5_6_2_Team03.domain.travelschedule.ScheduleStatus;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelRoute;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
-import grepp.NBE5_6_2_Team03.domain.travelschedule.ScheduleStatus;
-import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
 import jakarta.validation.constraints.NotBlank;
-import lombok.*;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDateTime;
-
-@Getter @Setter
+@Getter
+@Setter
 public class TravelScheduleRequest {
 
     private TravelRoute travelRoute;
@@ -31,7 +33,8 @@ public class TravelScheduleRequest {
     }
 
     @Builder
-    private TravelScheduleRequest(TravelRoute travelRoute, String content, String placeName, LocalDateTime travelScheduleDate, int expense) {
+    private TravelScheduleRequest(TravelRoute travelRoute, String content, String placeName,
+        LocalDateTime travelScheduleDate, int expense) {
         this.travelRoute = travelRoute;
         this.content = content;
         this.placeName = placeName;
@@ -39,28 +42,28 @@ public class TravelScheduleRequest {
         this.expense = expense;
     }
 
-    public TravelSchedule toEntity(TravelPlan plan,TravelScheduleRequest request, TravelTimeAiService aiService) {
+    public TravelSchedule toEntity(TravelPlan plan, TravelScheduleRequest request,
+        TravelTimeAiService aiService) {
 
         if (travelRouteExist(request)) {
 
             TravelTimeRequest aiRequest = new TravelTimeRequest(
-                this.travelRoute.getDeparture(),
-                this.travelRoute.getDestination(),
-                this.travelRoute.getTransportation()
+                request.getTravelRoute().getDeparture(),
+                request.getTravelRoute().getDestination(),
+                request.getTravelRoute().getTransportation()
             );
 
             TravelTimeResponse aiResponse = aiService.predictTime(aiRequest);
 
             travelRoute = new TravelRoute(
-                aiRequest.getDeparture(),
-                aiRequest.getDestination(),
-                aiRequest.getTransport(),
+                request.getTravelRoute().getDeparture(),
+                request.getTravelRoute().getDestination(),
+                request.getTravelRoute().getTransportation(),
                 aiResponse.getExpectedTime()
             );
         }
         return TravelSchedule.builder()
             .travelPlan(plan)
-            .travelRoute(travelRoute)
             .content(this.content)
             .placeName(this.placeName)
             .travelRoute(travelRoute)
@@ -70,7 +73,7 @@ public class TravelScheduleRequest {
             .build();
     }
 
-    private Boolean travelRouteExist(TravelScheduleRequest travelRoute) {
-        return travelRoute != null;
+    private Boolean travelRouteExist(TravelScheduleRequest request) {
+        return request.getTravelRoute() != null;
     }
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/travelSchedule/dto/request/TravelScheduleRequest.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/travelSchedule/dto/request/TravelScheduleRequest.java
@@ -1,5 +1,8 @@
 package grepp.NBE5_6_2_Team03.api.controller.schedule.travelSchedule.dto.request;
 
+import grepp.NBE5_6_2_Team03.api.controller.schedule.traveltimeai.dto.TravelTimeRequest;
+import grepp.NBE5_6_2_Team03.api.controller.schedule.traveltimeai.dto.TravelTimeResponse;
+import grepp.NBE5_6_2_Team03.domain.schedule.treveltimeai.service.TravelTimeAiService;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelRoute;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.ScheduleStatus;
@@ -36,7 +39,25 @@ public class TravelScheduleRequest {
         this.expense = expense;
     }
 
-    public TravelSchedule toEntity(TravelPlan plan) {
+    public TravelSchedule toEntity(TravelPlan plan,TravelScheduleRequest request, TravelTimeAiService aiService) {
+
+        if (travelRouteExist(request)) {
+
+            TravelTimeRequest aiRequest = new TravelTimeRequest(
+                this.travelRoute.getDeparture(),
+                this.travelRoute.getDestination(),
+                this.travelRoute.getTransportation()
+            );
+
+            TravelTimeResponse aiResponse = aiService.predictTime(aiRequest);
+
+            travelRoute = new TravelRoute(
+                aiRequest.getDeparture(),
+                aiRequest.getDestination(),
+                aiRequest.getTransport(),
+                aiResponse.getExpectedTime()
+            );
+        }
         return TravelSchedule.builder()
             .travelPlan(plan)
             .travelRoute(travelRoute)
@@ -47,5 +68,9 @@ public class TravelScheduleRequest {
             .travelScheduleDate(this.travelScheduleDate)
             .expense(this.expense)
             .build();
+    }
+
+    private Boolean travelRouteExist(TravelScheduleRequest travelRoute) {
+        return travelRoute != null;
     }
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/traveltimeai/dto/TravelTimeRequest.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/traveltimeai/dto/TravelTimeRequest.java
@@ -8,6 +8,11 @@ public class TravelTimeRequest {
     private String destination;
     private String transport;
 
-    public TravelTimeRequest(String departure, String destination, String transportation) {
+    public TravelTimeRequest(String departure, String destination, String transport) {
+        this.departure = departure;
+        this.destination = destination;
+        this.transport = transport;
     }
+
+
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/traveltimeai/dto/TravelTimeRequest.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/api/controller/schedule/traveltimeai/dto/TravelTimeRequest.java
@@ -7,4 +7,7 @@ public class TravelTimeRequest {
     private String departure;
     private String destination;
     private String transport;
+
+    public TravelTimeRequest(String departure, String destination, String transportation) {
+    }
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/TravelRoute.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/TravelRoute.java
@@ -10,13 +10,15 @@ public class TravelRoute {
     private String departure;
     private String destination;
     private String transportation;
+    private String expectedTime;
 
     protected TravelRoute() {
     }
 
-    public TravelRoute(String departure, String destination, String transportation) {
+    public TravelRoute(String departure, String destination, String transportation, String expectedTime) {
         this.departure = departure;
         this.destination = destination;
         this.transportation = transportation;
+        this.expectedTime = expectedTime;
     }
 }

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/service/TravelScheduleService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/service/TravelScheduleService.java
@@ -4,6 +4,7 @@ import grepp.NBE5_6_2_Team03.api.controller.schedule.travelSchedule.dto.request.
 import grepp.NBE5_6_2_Team03.api.controller.schedule.travelSchedule.dto.request.TravelScheduleRequest;
 import grepp.NBE5_6_2_Team03.api.controller.schedule.travelSchedule.dto.request.TravelScheduleStatusRequest;
 import grepp.NBE5_6_2_Team03.api.controller.schedule.travelSchedule.dto.response.GroupedTravelSchedulesResponse;
+import grepp.NBE5_6_2_Team03.domain.schedule.treveltimeai.service.TravelTimeAiService;
 import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
 import grepp.NBE5_6_2_Team03.domain.travelplan.repository.TravelPlanRepository;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelRoute;
@@ -26,6 +27,7 @@ public class TravelScheduleService {
 
     private final TravelScheduleRepository travelScheduleRepository;
     private final TravelPlanRepository travelPlanRepository;
+    private final TravelTimeAiService timeAiService;
 
     @Transactional
     public TravelSchedule createSchedule(Long travelPlanId, TravelScheduleRequest request) {
@@ -35,7 +37,7 @@ public class TravelScheduleService {
         validateTravelSchedule(request.getTravelRoute().getDeparture(), request.getTravelRoute().getDestination(), request.getTravelRoute().getTransportation(),
                                request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
 
-        TravelSchedule schedule = request.toEntity(plan);
+        TravelSchedule schedule = request.toEntity(plan, request, timeAiService);
         return travelScheduleRepository.save(schedule);
     }
 

--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/service/TravelScheduleService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/service/TravelScheduleService.java
@@ -12,13 +12,12 @@ import grepp.NBE5_6_2_Team03.domain.travelschedule.TravelSchedule;
 import grepp.NBE5_6_2_Team03.domain.travelschedule.repository.TravelScheduleRepository;
 import grepp.NBE5_6_2_Team03.global.exception.NotFoundException;
 import grepp.NBE5_6_2_Team03.global.message.ExceptionMessage;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -34,8 +33,9 @@ public class TravelScheduleService {
         TravelPlan plan = travelPlanRepository.findById(travelPlanId)
             .orElseThrow(() -> new NotFoundException(ExceptionMessage.PLANNED_NOT_FOUND));
 
-        validateTravelSchedule(request.getTravelRoute().getDeparture(), request.getTravelRoute().getDestination(), request.getTravelRoute().getTransportation(),
-                               request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
+        validateTravelSchedule(request.getTravelRoute().getDeparture(),
+            request.getTravelRoute().getDestination(), request.getTravelRoute().getTransportation(),
+            request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
 
         TravelSchedule schedule = request.toEntity(plan, request, timeAiService);
         return travelScheduleRepository.save(schedule);
@@ -48,8 +48,9 @@ public class TravelScheduleService {
 
         TravelPlan plan = schedule.getTravelPlan();
         TravelRoute travelRoute = request.getTravelRoute();
-        validateTravelSchedule(request.getTravelRoute().getDeparture(), request.getTravelRoute().getDestination(), request.getTravelRoute().getTransportation(),
-                               request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
+        validateTravelSchedule(request.getTravelRoute().getDeparture(),
+            request.getTravelRoute().getDestination(), request.getTravelRoute().getTransportation(),
+            request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
 
         schedule.edit(
             travelRoute,
@@ -71,7 +72,8 @@ public class TravelScheduleService {
     }
 
     @Transactional
-    public TravelSchedule editScheduleStatus(Long travelScheduleId, TravelScheduleStatusRequest request) {
+    public TravelSchedule editScheduleStatus(Long travelScheduleId,
+        TravelScheduleStatusRequest request) {
         TravelSchedule schedule = travelScheduleRepository.findById(travelScheduleId)
             .orElseThrow(() -> new NotFoundException(ExceptionMessage.SCHEDULE_NOT_FOUND));
 
@@ -80,7 +82,8 @@ public class TravelScheduleService {
     }
 
     public GroupedTravelSchedulesResponse getGroupedSchedules(Long travelPlanId) {
-        List<TravelSchedule> travelPlans = travelScheduleRepository.findByTravelPlanId(travelPlanId);
+        List<TravelSchedule> travelPlans = travelScheduleRepository.findByTravelPlanId(
+            travelPlanId);
         return GroupedTravelSchedulesResponse.from(travelPlans);
     }
 
@@ -89,7 +92,8 @@ public class TravelScheduleService {
             .orElseThrow(() -> new NotFoundException(ExceptionMessage.SCHEDULE_NOT_FOUND));
     }
 
-    private void validateTravelSchedule(String departure, String destination, String transportation, LocalDateTime travelScheduleDate, LocalDate travelStartDate, LocalDate travelEndDate) {
+    private void validateTravelSchedule(String departure, String destination, String transportation,
+        LocalDateTime travelScheduleDate, LocalDate travelStartDate, LocalDate travelEndDate) {
         boolean departureExists = departure != null && !departure.isBlank();
         boolean destinationExists = destination != null && !destination.isBlank();
         boolean transportationExists = transportation != null && !transportation.isBlank();
@@ -98,7 +102,8 @@ public class TravelScheduleService {
             throw new IllegalArgumentException("출발지, 도착지, 이동수단은 모두 입력하거나 모두 비워야 합니다.");
         }
 
-        if (travelScheduleDate.toLocalDate().isBefore(travelStartDate) || travelScheduleDate.toLocalDate().isAfter(travelEndDate)) {
+        if (travelScheduleDate.toLocalDate().isBefore(travelStartDate)
+            || travelScheduleDate.toLocalDate().isAfter(travelEndDate)) {
             throw new IllegalArgumentException("여행 일정 날짜는 여행 계획 날짜 안에 포함되어야 합니다.");
         }
     }

--- a/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepositoryTest.java
+++ b/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepositoryTest.java
@@ -35,9 +35,6 @@ class TravelPlanQueryRepositoryTest {
     @Autowired
     private TravelScheduleRepository travelScheduleRepository;
 
-    @Autowired
-    private ExpenseRepository expenseRepository;
-
     @DisplayName("여행 계획과 연관된 일정, 지출을 조회 한다.")
     @Test
     void getTravelPlanFetchScheduleAndExpense() {
@@ -50,10 +47,6 @@ class TravelPlanQueryRepositoryTest {
         TravelSchedule travelSchedule2 = createTravelSchedule(travelPlan, travelRoute, "일정 내용2", "장소 이름2");
         TravelSchedule travelSchedule3 = createTravelSchedule(travelPlan, travelRoute, "일정 내용3", "장소 이름3");
         travelScheduleRepository.saveAll(List.of(travelSchedule, travelSchedule2, travelSchedule3));
-
-        Expense expense = createExpense(travelSchedule, 1000);
-        Expense expense2 = createExpense(travelSchedule2, 2000);
-        expenseRepository.saveAll(List.of(expense, expense2));
 
         //when
         TravelPlan findTravelPlan = travelPlanQueryRepository.getTravelPlanWithSchedules(travelPlan.getTravelPlanId());
@@ -70,7 +63,7 @@ class TravelPlanQueryRepositoryTest {
     }
 
     private TravelRoute createTravelRoute() {
-        return new TravelRoute("출발지", "목적지", "이동수단");
+        return new TravelRoute("출발지", "목적지", "이동수단", "예상 이동 시간");
     }
 
     private TravelPlan createTravelPlan(Country country, String name, int publicMoney, int applicants){
@@ -88,13 +81,6 @@ class TravelPlanQueryRepositoryTest {
                 .travelRoute(travelRoute)
                 .content(content)
                 .placeName(placeName)
-                .build();
-    }
-
-    private Expense createExpense(TravelSchedule travelSchedule, int payedPrice){
-        return Expense.builder()
-                .travelSchedule(travelSchedule)
-                .payedPrice(payedPrice)
                 .build();
     }
 }

--- a/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepositoryTest.java
+++ b/tripin-service/src/test/java/grepp/NBE5_6_2_Team03/domain/travelplan/repository/TravelPlanQueryRepositoryTest.java
@@ -1,8 +1,6 @@
 package grepp.NBE5_6_2_Team03.domain.travelplan.repository;
 
 import grepp.NBE5_6_2_Team03.domain.adjustment.respository.AdjustmentRepository;
-import grepp.NBE5_6_2_Team03.domain.expense.Expense;
-import grepp.NBE5_6_2_Team03.domain.expense.repository.ExpenseRepository;
 import grepp.NBE5_6_2_Team03.domain.travelplan.Country;
 
 import grepp.NBE5_6_2_Team03.domain.travelplan.TravelPlan;
@@ -49,7 +47,7 @@ class TravelPlanQueryRepositoryTest {
         travelScheduleRepository.saveAll(List.of(travelSchedule, travelSchedule2, travelSchedule3));
 
         //when
-        TravelPlan findTravelPlan = travelPlanQueryRepository.getTravelPlanWithSchedules(travelPlan.getTravelPlanId());
+        TravelPlan findTravelPlan = travelPlanQueryRepository.getTravelPlanWithSchedules(travelPlan.getId());
 
         //then
         assertThat(findTravelPlan).isNotNull();


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
여행 일정 생성 시점에 AI 예상 시간 저장
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 테스트 관련해서 expense 테이블을 삭제해서 에러가 나던 것을 삭제했습니다.
- 여행 일정 저장 시에 AI 예상 이동 시간을 함께 TravelRoute에 저장하도록 기능 추가했습니다.

![image](https://github.com/user-attachments/assets/db3e937e-0d60-4c05-bccc-9177fb159dcc)

----------------------------------------------------------------------------------------------

![image](https://github.com/user-attachments/assets/0dc5b5ae-2d28-45a4-8909-40e89a963651)

