### PR TITLE
Fix: TravelSchedule Validation 분리 (Route, Date)

### DIFF
--- a/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/service/TravelScheduleService.java
+++ b/tripin-service/src/main/java/grepp/NBE5_6_2_Team03/domain/travelschedule/service/TravelScheduleService.java
@@ -39,10 +39,11 @@ public class TravelScheduleService {
         TravelRouteRequest currentTravelRouteRequest = request.getTravelRouteRequest();
 
         if (travelRouteExist(currentTravelRouteRequest)) {
-            validateTravelSchedule(currentTravelRouteRequest.getDeparture(),
-                currentTravelRouteRequest.getDestination(), currentTravelRouteRequest.getTransportation(),
-                request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
+            validateTravelScheduleRoute(currentTravelRouteRequest.getDeparture(),
+                currentTravelRouteRequest.getDestination(), currentTravelRouteRequest.getTransportation());
         }
+
+        validateTravelScheduleDate(request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
 
         TravelSchedule schedule = request.toEntity(plan, request, timeAiService);
         return travelScheduleRepository.save(schedule);
@@ -59,14 +60,15 @@ public class TravelScheduleService {
         TravelRouteRequest currentTravelRouteRequest = request.getTravelRouteRequest();
 
         if (travelRouteExist(currentTravelRouteRequest)) {
-            validateTravelSchedule(currentTravelRouteRequest.getDeparture(),
-                currentTravelRouteRequest.getDestination(), currentTravelRouteRequest.getTransportation(),
-                request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
+            validateTravelScheduleRoute(currentTravelRouteRequest.getDeparture(),
+                currentTravelRouteRequest.getDestination(), currentTravelRouteRequest.getTransportation());
 
             travelRoute = currentTravelRouteRequest.toEntity(currentTravelRouteRequest, timeAiService);
         } else {
             travelRoute = schedule.getTravelRoute(); // 따로 요청 사항이 없다면 기존의 route 유지
         }
+
+        validateTravelScheduleDate(request.getTravelScheduleDate(), plan.getTravelStartDate(), plan.getTravelEndDate());
 
         schedule.edit(
             travelRoute,
@@ -116,8 +118,7 @@ public class TravelScheduleService {
             .anyMatch(s -> s != null && !s.isBlank());
     }
 
-    private void validateTravelSchedule(String departure, String destination, String transportation,
-        LocalDateTime travelScheduleDate, LocalDate travelStartDate, LocalDate travelEndDate) {
+    private void validateTravelScheduleRoute(String departure, String destination, String transportation) {
         boolean departureExists = departure != null && !departure.isBlank();
         boolean destinationExists = destination != null && !destination.isBlank();
         boolean transportationExists = transportation != null && !transportation.isBlank();
@@ -125,7 +126,10 @@ public class TravelScheduleService {
         if (!(departureExists == destinationExists && destinationExists == transportationExists)) {
             throw new IllegalArgumentException("출발지, 도착지, 이동수단은 모두 입력하거나 모두 비워야 합니다.");
         }
+    }
 
+    private void validateTravelScheduleDate(LocalDateTime travelScheduleDate, LocalDate travelStartDate,
+        LocalDate travelEndDate) {
         if (travelScheduleDate.toLocalDate().isBefore(travelStartDate)
             || travelScheduleDate.toLocalDate().isAfter(travelEndDate)) {
             throw new IllegalArgumentException("여행 일정 날짜는 여행 계획 날짜 안에 포함되어야 합니다.");


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
TravelSchedule에 대한 검증 로직은 Route와 Date에 대한 메서드로 분리하고 Date에 대한 로직은 항상 돌아갈 수 있도록 구현했습니다.

#### Create
- TravelRouteRequest가 필드에 없을 때, 날짜가 계획 기간 밖일 때
![Screenshot 2025-06-18 at 1 51 28 PM](https://github.com/user-attachments/assets/3a8f7b6d-38fb-474e-bff9-9f3974b669e5)

- 모든 필드가 존재할 때, 날짜가 계획 기간 밖일 때
![Screenshot 2025-06-18 at 1 53 16 PM](https://github.com/user-attachments/assets/583fc01e-048b-44dd-8621-9ef77d689617)

#### Edit

- 모든 필드가 존재할 때, 날짜가 계획기간 밖일때
![Screenshot 2025-06-18 at 1 41 46 PM](https://github.com/user-attachments/assets/05fcb420-30b2-4a56-82a0-cd9b0a6377e9)

- TravelRoute 필드가 없을 때, 날짜가 계획기간 밖일때
![Screenshot 2025-06-18 at 1 41 59 PM](https://github.com/user-attachments/assets/3bb740f2-fe7e-4c8c-be43-2b163779779c)

TravelRouteRequest의 검증이 돌기 때문에 TravelRouteReqest 값이 양식에 맞지않는 경우(출발지, 도착지, 이동수단 중 1개 이상 누락)에 대한 예외처리가 먼저 수행됩니다.
